### PR TITLE
Add kumo-tablist

### DIFF
--- a/packages/web-components/src/index-rollup.ts
+++ b/packages/web-components/src/index-rollup.ts
@@ -51,4 +51,6 @@ import './kumo/menu-button/define.js';
 import './kumo/progress-bar/define.js';
 import './kumo/radio/define.js';
 import './kumo/radio-group/define.js';
+import './kumo/tab/define.js';
+import './kumo/tablist/define.js';
 import './kumo/text-input/define.js';

--- a/packages/web-components/src/kumo/tab/define.ts
+++ b/packages/web-components/src/kumo/tab/define.ts
@@ -1,0 +1,3 @@
+import { definition } from './tab.definition.js';
+
+definition.define();

--- a/packages/web-components/src/kumo/tab/tab.definition.ts
+++ b/packages/web-components/src/kumo/tab/tab.definition.ts
@@ -1,0 +1,16 @@
+import { Tab } from '../../tab/tab.js';
+import { template } from '../../tab/tab.template.js';
+import { styles } from '../../tab/tab.styles.js';
+
+/**
+ * The Kumo Tab element definition.
+ *
+ * @public
+ * @remarks
+ * HTML Element: `<kumo-tablist>`
+ */
+export const definition = Tab.compose({
+  name: `kumo-tab`,
+  template,
+  styles,
+});

--- a/packages/web-components/src/kumo/tab/tab.definition.ts
+++ b/packages/web-components/src/kumo/tab/tab.definition.ts
@@ -7,7 +7,7 @@ import { styles } from '../../tab/tab.styles.js';
  *
  * @public
  * @remarks
- * HTML Element: `<kumo-tablist>`
+ * HTML Element: `<kumo-tab>`
  */
 export const definition = Tab.compose({
   name: `kumo-tab`,

--- a/packages/web-components/src/kumo/tablist/define.ts
+++ b/packages/web-components/src/kumo/tablist/define.ts
@@ -1,0 +1,3 @@
+import { definition } from './tablist.definition.js';
+
+definition.define();

--- a/packages/web-components/src/kumo/tablist/tablist.definition.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.definition.ts
@@ -1,0 +1,16 @@
+import { template } from '../../tablist/tablist.template.js';
+import { KumoTablist } from './tablist.js';
+import { styles } from './tablist.styles.js';
+
+/**
+ * The Kumo Tablist Element definition.
+ *
+ * @public
+ * @remarks
+ * HTML Element: `<kumo-tablist>`
+ */
+export const definition = KumoTablist.compose({
+  name: `kumo-tablist`,
+  template,
+  styles,
+});

--- a/packages/web-components/src/kumo/tablist/tablist.definition.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.definition.ts
@@ -1,5 +1,5 @@
 import { template } from '../../tablist/tablist.template.js';
-import { KumoTablist } from './tablist.js';
+import { BaseTablist as KumoTablist } from '../../tablist/tablist.js';
 import { styles } from './tablist.styles.js';
 
 /**

--- a/packages/web-components/src/kumo/tablist/tablist.stories.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.stories.ts
@@ -1,0 +1,145 @@
+import { html } from '@microsoft/fast-element';
+import type { Args, Meta } from '@storybook/html';
+import { renderComponent } from '../../helpers.stories.js';
+import { TablistOrientation } from '../../tablist/tablist.options.js';
+import type { KumoTablist } from './tablist.js';
+
+type TablistStoryArgs = Args & KumoTablist;
+type TablistStoryMeta = Meta<TablistStoryArgs>;
+
+const tabIds = ['first-tab', 'second-tab', 'third-tab', 'fourth-tab'];
+
+function changeTab() {
+  const tablist = document.querySelector('kumo-tablist') as KumoTablist;
+  const panelPlaceholder = document.querySelector('#panel-placeholder')!;
+  // there's a million ways to do this, but this is the simplest
+  panelPlaceholder.innerHTML = `
+  <div role="tabpanel" aria-labelledby="tablist.activeid">
+    Tab changed to ${tablist.activeid}
+  </div>`;
+}
+
+const tabsDefault = html`
+  <style>
+    #demo-layout {
+      display: grid;
+      gap: 1rem;
+    }
+    #demo-layout:has(kumo-tablist[orientation='vertical']) {
+      grid-template-columns: max-content 1fr;
+    }
+  </style>
+  <div id="demo-layout">
+    <kumo-tablist
+      orientation=${x => x.orientation}
+      ?disabled=${x => x.disabled}
+      activeid=${x => x.activeid}
+      @change="${() => changeTab()}"
+    >
+      <kumo-tab id=${tabIds[0]}> First Tab </kumo-tab>
+      <kumo-tab id=${tabIds[1]}> Second Tab</kumo-tab>
+      <kumo-tab id=${tabIds[2]}> Third Tab</kumo-tab>
+      <kumo-tab id=${tabIds[3]}> Fourth Tab</kumo-tab>
+    </kumo-tablist>
+
+    <div id="panel-placeholder"></div>
+  </div>
+`;
+export const TablistDefault = renderComponent(tabsDefault).bind({});
+
+const tabsHorizontal = html`
+  <kumo-tablist orientation="horizontal">
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+`;
+export const TablistHorizontal = renderComponent(tabsHorizontal).bind({});
+
+const tabsVertical = html`
+  <kumo-tablist orientation="vertical">
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+`;
+export const TablistVertical = renderComponent(tabsVertical).bind({});
+
+const tabsDisabledTablist = html`
+  <kumo-tablist disabled>
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+  <kumo-tablist>
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab disabled> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+`;
+export const TablistDisabled = renderComponent(tabsDisabledTablist).bind({});
+
+const tabsSizeMedium = html`
+  <kumo-tablist size="medium">
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+  <br />
+  <kumo-tablist size="medium" orientation="vertical">
+    <kumo-tab> First Tab </kumo-tab>
+    <kumo-tab> Second Tab</kumo-tab>
+    <kumo-tab> Third Tab</kumo-tab>
+    <kumo-tab> Fourth Tab</kumo-tab>
+  </kumo-tablist>
+`;
+export const TablistSizeMedium = renderComponent(tabsSizeMedium).bind({});
+
+const rtl = html`
+  <div dir="rtl">
+    <kumo-tablist>
+      <kumo-tab> First Tab </kumo-tab>
+      <kumo-tab> Second Tab</kumo-tab>
+      <kumo-tab> Third Tab</kumo-tab>
+      <kumo-tab> Fourth Tab</kumo-tab>
+    </kumo-tablist>
+    <br />
+    <kumo-tablist orientation="vertical">
+      <kumo-tab> First Tab </kumo-tab>
+      <kumo-tab> Second Tab</kumo-tab>
+      <kumo-tab> Third Tab</kumo-tab>
+      <kumo-tab> Fourth Tab</kumo-tab>
+    </kumo-tablist>
+  </div>
+`;
+export const RTL = renderComponent(rtl).bind({});
+
+export default {
+  title: 'Components/Kumo/Tablist',
+  args: {
+    disabled: false,
+    orientation: 'horizontal',
+  },
+  argTypes: {
+    activeid: {
+      options: tabIds,
+      defaultValue: tabIds[0],
+      control: { type: 'select' },
+    },
+    disabled: {
+      options: [true, false],
+      defaultValue: false,
+      control: { type: 'select' },
+    },
+    orientation: {
+      options: Object.values(TablistOrientation),
+      defaultValue: TablistOrientation.horizontal,
+      control: { type: 'select' },
+    },
+  },
+} as TablistStoryMeta;

--- a/packages/web-components/src/kumo/tablist/tablist.stories.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.stories.ts
@@ -2,7 +2,7 @@ import { html } from '@microsoft/fast-element';
 import type { Args, Meta } from '@storybook/html';
 import { renderComponent } from '../../helpers.stories.js';
 import { TablistOrientation } from '../../tablist/tablist.options.js';
-import type { KumoTablist } from './tablist.js';
+import type { BaseTablist as KumoTablist } from '../../tablist/tablist.js';
 
 type TablistStoryArgs = Args & KumoTablist;
 type TablistStoryMeta = Meta<TablistStoryArgs>;

--- a/packages/web-components/src/kumo/tablist/tablist.styles.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.styles.ts
@@ -1,0 +1,84 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../../utils/index.js';
+import {
+  colorNeutralForeground2,
+  colorNeutralForegroundDisabled,
+  spacingVerticalS,
+  strokeWidthThicker,
+} from '../../theme/design-tokens.js';
+import { disabledState, verticalState } from '../../styles/states/index.js';
+/**
+ * @public
+ */
+export const styles = css`
+  ${display('flex')}
+
+  :host {
+    --tabPaddingInline: inherit;
+    --tabPaddingBlock: inherit;
+    box-sizing: border-box;
+    color: ${colorNeutralForeground2};
+    flex-direction: row;
+  }
+
+  :host(${verticalState}) {
+    flex-direction: column;
+  }
+
+  :host ::slotted([role='tab']) {
+    align-items: flex-start;
+  }
+
+  :host ::slotted([slot='tab'])::after {
+    height: ${strokeWidthThicker};
+    margin-block-start: auto;
+  }
+
+  :host(${verticalState}) ::slotted([slot='tab'])::after {
+    width: ${strokeWidthThicker};
+    height: unset;
+    margin-block-start: unset;
+  }
+
+  :host ::slotted([slot='tab'][aria-selected='true'])::before {
+    background-color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host ::slotted([slot='tab'][aria-selected='false']:hover)::after {
+    height: ${strokeWidthThicker};
+    margin-block-start: auto;
+    transform-origin: left;
+  }
+
+  :host(${verticalState}) ::slotted([slot='tab'])::before,
+  :host(${verticalState}) ::slotted([slot='tab'][aria-selected='false']:hover)::after {
+    height: unset;
+    width: ${strokeWidthThicker};
+    margin-inline-end: auto;
+    transform-origin: top;
+  }
+
+  :host(${verticalState}) ::slotted([slot='tab']) {
+    padding-block: var(--tabPaddingBlock);
+  }
+
+  :host(${verticalState}) ::slotted([slot='tab']) {
+    --tabPaddingBlock: ${spacingVerticalS};
+  }
+
+  /* disabled styles */
+  :host(${disabledState}) {
+    cursor: not-allowed;
+    color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host(${disabledState}) ::slotted([slot='tab']) {
+    pointer-events: none;
+    cursor: not-allowed;
+    color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host(${disabledState}) ::slotted([slot='tab']:hover):before {
+    content: unset;
+  }
+`;

--- a/packages/web-components/src/kumo/tablist/tablist.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.ts
@@ -1,7 +1,0 @@
-import { BaseTablist } from '../../tablist/tablist.js';
-
-/**
- * Kumo tablist.
- * @public
- */
-export class KumoTablist extends BaseTablist {}

--- a/packages/web-components/src/kumo/tablist/tablist.ts
+++ b/packages/web-components/src/kumo/tablist/tablist.ts
@@ -1,0 +1,7 @@
+import { BaseTablist } from '../../tablist/tablist.js';
+
+/**
+ * Kumo tablist.
+ * @public
+ */
+export class KumoTablist extends BaseTablist {}


### PR DESCRIPTION
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Adds kumo-tablist and kumo-tab.

- Kumo tab is a clone of Fluent tab
- Kumo tablist extends BaseTablist and has basic indicator styling (still pending) and all appearance options ripped out (still pending)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
