### PR TITLE
Add kumo-link

### DIFF
--- a/packages/web-components/src/index-rollup.ts
+++ b/packages/web-components/src/index-rollup.ts
@@ -47,6 +47,7 @@ import './kumo/checkbox/define.js';
 import './kumo/dialog/define.js';
 import './kumo/dialog-body/define.js';
 import './kumo/field/define.js';
+import './kumo/link/define.js';
 import './kumo/menu-button/define.js';
 import './kumo/progress-bar/define.js';
 import './kumo/radio/define.js';

--- a/packages/web-components/src/kumo/link/define.ts
+++ b/packages/web-components/src/kumo/link/define.ts
@@ -1,0 +1,3 @@
+import { definition } from './link.definition.js';
+
+definition.define();

--- a/packages/web-components/src/kumo/link/link.definition.ts
+++ b/packages/web-components/src/kumo/link/link.definition.ts
@@ -1,0 +1,16 @@
+import { Link } from '../../link/link.js';
+import { template } from '../../link/link.template.js';
+import { styles } from '../../link/link.styles.js';
+
+/**
+ * The definition for the Kumo Link component.
+ *
+ * @public
+ * @remarks
+ * HTML Element: `<kumo-link>`
+ */
+export const definition = Link.compose({
+  name: `kumo-link`,
+  template,
+  styles,
+});

--- a/packages/web-components/src/kumo/link/link.stories.ts
+++ b/packages/web-components/src/kumo/link/link.stories.ts
@@ -1,0 +1,71 @@
+import { html } from '@microsoft/fast-element';
+import type { Args, Meta } from '@storybook/html';
+import { renderComponent } from '../../helpers.stories.js';
+import type { Link as KumoLink } from '../../link/link.js';
+import { LinkAppearance } from '../../link/link.options.js';
+
+type LinkStoryArgs = Args & KumoLink;
+type LinkStoryMeta = Meta<LinkStoryArgs>;
+
+const storyTemplate = html<LinkStoryArgs>`
+  <kumo-link href="${x => x.href}" appearance="${x => x.appearance}">${x => x.content}</kumo-link>
+`;
+
+export default {
+  title: 'Components/Kumo/Link',
+  args: {
+    content: 'Link',
+    href: '#',
+    disabled: false,
+    disabledFocusable: false,
+  },
+  argTypes: {
+    content: {
+      control: 'Anchor text',
+    },
+    appearance: {
+      options: ['default', ...Object.values(LinkAppearance)],
+      control: {
+        type: 'select',
+      },
+    },
+    href: {
+      control: 'text',
+    },
+  },
+} as LinkStoryMeta;
+
+export const Link = renderComponent(storyTemplate).bind({});
+
+export const Appearance = renderComponent(html<LinkStoryArgs>`
+  <kumo-link href="#" appearance="subtle">Subtle</kumo-link>
+`);
+
+export const Inline = renderComponent(html<LinkStoryArgs>`
+  <fluent-text
+    ><p>
+      This is an <kumo-link href="#" inline>inline link</kumo-link> used alongside text within the
+      <code>fluent-text</code> component.
+    </p></fluent-text
+  >
+  <p>This is an <kumo-link href="#" inline>inline link</kumo-link> used alongside a <code>p</code> element.</p>
+  <h4>
+    This is an <kumo-link href="#">inline link without the inline attribute</kumo-link> within a
+    <code>h4</code> element. In Chromium browsers, the link inherits without the use of the
+    <code>inline</code> attribute.
+  </h4>
+`);
+
+export const Wrapping = renderComponent(html<LinkStoryArgs>`
+  <style>
+    .max-width {
+      display: block;
+      width: 250px;
+    }
+  </style>
+  <p class="max-width">
+    This paragraph contains a link which is very long.
+    <kumo-link href="#">Kumo links wrap correctly between lines when they are very long.</kumo-link> This is because
+    they are inline elements.
+  </p>
+`);


### PR DESCRIPTION
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Adds Kumo Link. Currently extends Fluent Link because it would need to support Subtle appearance and inline usage (Usage like this is not reflected in Figma yet) 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
